### PR TITLE
Updated message_block to remove all markup if no flash messages or errors are found 

### DIFF
--- a/lib/message_block/helpers.rb
+++ b/lib/message_block/helpers.rb
@@ -43,10 +43,12 @@ module MessageBlock
         "<ul class=\"#{type}\">" + flash_messages[type.to_sym].map {|message| "<li>#{message}</li>" }.join + "</ul>"
       end.join
       
-      if options[:container]
-        content_tag(options[:container], contents, options[:html], false)
-      else
-        contents
+      unless contents.blank?
+        if options[:container]
+          content_tag(options[:container], contents, options[:html], false)
+        else
+          contents
+        end
       end
     end
     

--- a/spec/message_block/helpers_spec.rb
+++ b/spec/message_block/helpers_spec.rb
@@ -22,7 +22,7 @@ describe MessageBlock::Helpers do
   end
   
   it "should show nothing with no errors" do
-    message_block.should == %(<div class="message_block" id="message_block"></div>)
+    message_block.should == ''
   end
   
   it "should automatically find post errors with posts controller" do


### PR DESCRIPTION
Message block presents messages and errors in a containing div element.

However, when no messages or errors are present, the containing div element is still injected into the view. This extra markup can create unnecessary white space in views. To fix this, goofy workarounds are often required.

So when no messages or errors are present, it's best if message_block does not generate any markup.
